### PR TITLE
Macos build fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       run: make
 
   build-osx:
-    runs-on: macos-11.0
+    runs-on: macos-10.15
     strategy:
       fail-fast: false
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 kmw - Kurt M. Weber <weberk294@gmail.com>
 tge - Tom Everett <tom@khubla.com>
+jrs - Jeff schnurr <jschnurr@gmail.com>

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -43,7 +43,10 @@ Backtrace stopped: previous frame inner to this frame (corrupt stack?)
 ```
 
 ## VSCode debugging
-If you prefer VSCode, configure `launch.json` like so:
+If you prefer VSCode, you need two things:
+
+1. Install the [Native Debug](https://github.com/WebFreak001/code-debug) plugin from Webfreak. 
+2. configure `launch.json` like so:
 
 ```json
 {


### PR DESCRIPTION
Microsoft withdrew macos11 support for Github Actions temporarily, causing our builds to fail. Downgrade the macos runner for now.
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on